### PR TITLE
client: add reticule selector for all explorers

### DIFF
--- a/client/src/app/board/GameUIManager.ts
+++ b/client/src/app/board/GameUIManager.ts
@@ -330,8 +330,8 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
   }
 
   // mining stuff
-  setMiningPattern(pattern: MiningPattern) {
-    this.gameManager.setMiningPattern(pattern);
+  setMiningPattern(pattern: MiningPattern, whichExplorer) {
+    this.gameManager.setMiningPattern(pattern, whichExplorer);
   }
   getMiningPattern(): MiningPattern | null {
     return this.gameManager.getMiningPattern();
@@ -628,7 +628,7 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
     return this.gameManager.getSilverCurveAtPercent(planet, percent);
   }
 
-  getHashesPerSec(): number {
+  getHashesPerSec(): [string, number] {
     return this.gameManager.getHashesPerSec();
   }
 
@@ -726,6 +726,10 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
 
   private onEmitInitializedPlayerError(err) {
     this.emit(GameUIManagerEvent.InitializedPlayerError, err);
+  }
+
+  getExplorers() {
+    return this.gameManager.explorers;
   }
 }
 


### PR DESCRIPTION
@jacobrosenthal This adds a reticule next to each explorer that will allow you to set its central explore location.

I also did a bunch of cleanup of stuff that we don't really use any more due to my hacking.