### PR TITLE
explorer: implement chunk syncing with all clients

### DIFF
--- a/client/src/api/GameManager.ts
+++ b/client/src/api/GameManager.ts
@@ -383,18 +383,28 @@ class GameManager extends EventEmitter implements AbstractGameManager {
 
       this.explorerIPs.forEach((ip) => {
         const explorer = new window.Primus(ip);
-        explorer.on('sync-map', (chunks) => {
-          chunks.forEach((chunk) => this.addNewChunk(chunk));
-        });
-        explorer.on('new-chunk', (chunk) => {
-          this.lastChunkPerExplorer.set(ip, chunk.chunkFootprint);
-          this.addNewChunk(chunk);
-          this.emit(GameManagerEvent.DiscoveredNewChunk, chunk);
+        const syncChunk = (chunk) => {
           this.explorers.forEach((otherExplorer, otherIp) => {
             if (ip !== otherIp) {
               otherExplorer.emit('sync-chunk', chunk);
             }
           });
+        };
+
+        explorer.on('sync-map', (chunks) => {
+          chunks.forEach((chunk) => {
+            this.addNewChunk(chunk);
+            syncChunk(chunk);
+          });
+        });
+        explorer.on('new-chunk', (chunk) => {
+          this.lastChunkPerExplorer.set(ip, chunk.chunkFootprint);
+          this.addNewChunk(chunk);
+          this.emit(GameManagerEvent.DiscoveredNewChunk, chunk);
+          syncChunk(chunk);
+        });
+        explorer.on('new-sync-chunk', (chunk) => {
+          this.addNewChunk(chunk);
         });
         explorer.on('hash-rate', (hashRate) => {
           this.hashRatePerExplorer.set(ip, hashRate);

--- a/index.mjs
+++ b/index.mjs
@@ -181,7 +181,7 @@ if (isWebsocketServer) {
       localStorageManager.updateChunk(chunk, false);
       primus.forEach((otherSpark, otherId) => {
         if (otherId !== spark.id) {
-          otherSpark.emit('new-chunk', chunk);
+          otherSpark.emit('new-sync-chunk', chunk);
         }
       });
     });


### PR DESCRIPTION
This adds 2 new events to sync chunks between all explorers a game client is connected to.

Chunk syncing is currently managed by the game client instead of the explorers themselves. Ideally that wouldn't be a case and the explorers could actually swarm themselves.

I'm not sure of the performance implications of this code because we are mining so fast that tons of events are being pushed around. Also, there is a huge delay on startup (after you hit "enter") because it does a complete map sync between connected clients.

@jacobrosenthal this requires an explorer restart as well.