### PR TITLE
client: switch planets to a Map for performance

### DIFF
--- a/client/src/_types/global/GlobalTypes.ts
+++ b/client/src/_types/global/GlobalTypes.ts
@@ -182,9 +182,7 @@ export interface ArrivalWithTimer {
   timer: ReturnType<typeof setTimeout>;
 }
 
-export interface PlanetMap {
-  [planetId: string]: Planet;
-}
+export type PlanetMap = Map<string, Planet>
 
 export interface PlanetLocationMap {
   [planetId: string]: Location;

--- a/client/src/api/ContractsAPI.ts
+++ b/client/src/api/ContractsAPI.ts
@@ -770,7 +770,7 @@ class ContractsAPI extends EventEmitter {
       true
     );
 
-    const planets: PlanetMap = {};
+    const planets: PlanetMap = new Map();
     for (let i = 0; i < nPlanets; i += 1) {
       if (!!rawPlanets[i] && !!rawPlanetsExtendedInfo[i]) {
         const planet = this.rawPlanetToObject(
@@ -778,7 +778,7 @@ class ContractsAPI extends EventEmitter {
           rawPlanets[i],
           rawPlanetsExtendedInfo[i]
         );
-        planets[planet.locationId as string] = planet;
+        planets.set(planet.locationId, planet);
       }
     }
     return planets;

--- a/client/src/api/GameManager.ts
+++ b/client/src/api/GameManager.ts
@@ -203,10 +203,8 @@ class GameManager extends EventEmitter implements AbstractGameManager {
     // fetch planets after allArrivals, since an arrival to a new planet might be sent
     // while we are fetching
     const planets = await contractsAPI.getPlanets();
-    for (const planetId in planets) {
-      if (planets.hasOwnProperty(planetId)) {
-        planetVoyageIdMap[planetId] = [];
-      }
+    for (let planetId of planets.keys()) {
+      planetVoyageIdMap[planetId] = [];
     }
     for (const arrival of allArrivals) {
       planetVoyageIdMap[arrival.toPlanet].push(arrival.eventId);

--- a/client/src/app/board/CanvasRenderer.ts
+++ b/client/src/app/board/CanvasRenderer.ts
@@ -52,8 +52,7 @@ class CanvasRenderer {
     image: HTMLImageElement
   ) {
     this.canvas = canvas;
-    this.offscreenCanvas = new OffscreenCanvas(canvas.width, canvas.height);
-    const ctx = this.offscreenCanvas.getContext('2d', {
+    const ctx = canvas.getContext('2d', {
       // https://developers.google.com/web/updates/2019/05/desynchronized
       desynchronized: true,
       // https://wiki.whatwg.org/wiki/Canvas_Context_Loss_and_Restoration
@@ -104,14 +103,6 @@ class CanvasRenderer {
     CanvasRenderer.instance = canvasRenderer;
 
     return canvasRenderer;
-  }
-
-  setWidth(width) {
-    this.offscreenCanvas.width = width;
-  }
-
-  setHeight(height) {
-    this.offscreenCanvas.height = height;
   }
 
   private frame() {

--- a/client/src/app/board/ControllableCanvas.tsx
+++ b/client/src/app/board/ControllableCanvas.tsx
@@ -50,10 +50,6 @@ export default function ControllableCanvas() {
       setHeight(canvasRef.current.clientHeight);
       uiEmitter.emit(UIEmitterEvent.WindowResize);
     }
-    if (CanvasRenderer.instance) {
-      CanvasRenderer.instance.setWidth(canvasRef.current.clientWidth);
-      CanvasRenderer.instance.setHeight(canvasRef.current.clientHeight);
-    }
   }, [uiEmitter]);
 
   useLayoutEffect(() => {

--- a/client/src/app/board/GameUIManager.ts
+++ b/client/src/app/board/GameUIManager.ts
@@ -262,7 +262,7 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
 
         const dist = Math.sqrt(
           (mouseDownCoords.x - mouseUpOverCoords.x) ** 2 +
-            (mouseDownCoords.y - mouseUpOverCoords.y) ** 2
+          (mouseDownCoords.y - mouseUpOverCoords.y) ** 2
         );
         const myAtk: number = moveShipsDecay(forces, mouseDownPlanet, dist);
         const effPercentSilver = Math.min(
@@ -701,7 +701,7 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
         if (
           planet &&
           this.radiusMap[planet.planetLevel] >
-            Math.max(Math.abs(x - coords.x), Math.abs(y - coords.y))
+          Math.max(Math.abs(x - coords.x), Math.abs(y - coords.y))
         ) {
           // coords is in hitbox
           if (this.radiusMap[planet.planetLevel] < smallestPlanetRadius) {


### PR DESCRIPTION
> With this one quick trick, you too can have game client performance 🎉 

This just switched the planets object mapping to an actual Map and now `getAllOwnedPlanets` barely shows up in the bottom-up view.
