### PR TITLE
client: more perf tweaks, including removing tooltips

### DIFF
--- a/client/src/api/PlanetHelper.ts
+++ b/client/src/api/PlanetHelper.ts
@@ -105,11 +105,9 @@ export class PlanetHelper {
     // set interval to update all planets every 120s
     setInterval(() => {
       for (let planet of this.planets.values()) {
-        setTimeout(() => {
-          if (planet && hasOwner(planet)) {
-            this.updatePlanetToTime(planet, Date.now());
-          }
-        }, Math.floor(120000 * Math.random())); // evenly distribute updates
+        if (planet && hasOwner(planet)) {
+          this.updatePlanetToTime(planet, Date.now());
+        }
       }
     }, 120000);
   }

--- a/client/src/app/GameWindowPanes/Tooltip.tsx
+++ b/client/src/app/GameWindowPanes/Tooltip.tsx
@@ -19,27 +19,10 @@ type TooltipProps = {
   className?: string;
 };
 
-const fadeShift = keyframes`
-  from {
-    background: ${dfstyles.colors.dfblue}; 
-  }
-  to {
-    background: ${dfstyles.colors.backgroundlight};
-  }
-`;
-
-const animation = css`
-  animation: ${fadeShift} 1s ${dfstyles.game.styles.animProps};
-`;
-
-// background: ${(props) => props.anim ? dfstyles.colors.dfblue : 'none' };
 const StyledTooltipTrigger = styled.span<{
-  anim: boolean;
   display?: DisplayType;
 }>`
   border-radius: 2px;
-  transition: background 0.2s;
-  ${(props) => (props.anim ? animation : 'animation: none;')}
 
   display: ${(props) => props.display || 'inline'};
 `;
@@ -52,65 +35,18 @@ export function TooltipTrigger({
   style,
   className,
 }: TooltipProps) {
-  // the model for this is a state machine on the state of {shift, hovering}
-  const [shift, setShift] = useState<boolean>(false);
-  const [hovering, setHovering] = useState<boolean>(false);
-
-  const [pushed, setPushed] = useState<boolean>(false);
-
-  const windowManager = WindowManager.getInstance();
-
-  useEffect(() => {
-    const doShiftDown = () => setShift(true);
-    const doShiftUp = () => setShift(false);
-
-    windowManager.on(WindowManagerEvent.ShiftDown, doShiftDown);
-    windowManager.on(WindowManagerEvent.ShiftUp, doShiftUp);
-    return () => {
-      windowManager.removeListener(WindowManagerEvent.ShiftDown, doShiftDown);
-      windowManager.removeListener(WindowManagerEvent.ShiftUp, doShiftUp);
-    };
-  }, [windowManager]);
-
-  // manage state machine
-  useEffect(() => {
-    const getShift = () => {
-      if (!needsShift) return true;
-      else return shift;
-    };
-
-    if (!pushed) {
-      // not pushed yet
-      if (hovering && getShift()) {
-        windowManager.pushTooltip(name);
-        setPushed(true);
-      }
-    } else {
-      // is pushed already
-      if (!hovering || !getShift()) {
-        windowManager.popTooltip();
-        setPushed(false);
-      }
-    }
-  }, [hovering, shift, pushed, windowManager, name, needsShift]);
-
   return (
     <StyledTooltipTrigger
       display={display}
       style={{ ...style }}
       className={className}
-      anim={shift}
-      onMouseEnter={() => setHovering(true)}
-      onMouseLeave={() => setHovering(false)}
     >
       {children}
     </StyledTooltipTrigger>
   );
 }
 
-const StyledTooltip = styled.div<{
-  visible: boolean;
-}>`
+const StyledTooltip = styled.div`
   position: absolute;
   width: fit-content;
   height: fit-content;
@@ -122,99 +58,10 @@ const StyledTooltip = styled.div<{
   border-radius: 3px;
 
   z-index: ${GameWindowZIndex.Tooltip};
-  display: ${(props) => (props.visible ? 'block' : 'none')};
 `;
 
 export function Tooltip() {
-  const [top, setTop] = useState<number>(0);
-  const [left, setLeft] = useState<number>(0);
-
-  const [visible, setVisible] = useState<boolean>(false);
-
-  const windowManager = WindowManager.getInstance();
-
-  const [current, setCurrent] = useState<TooltipName>(TooltipName.None);
-
-  const [leftOffset, setLeftOffset] = useState<number>(10);
-  const [topOffset, setTopOffset] = useState<number>(10);
-
-  const elRef = useRef<HTMLDivElement>(document.createElement('div'));
-  const [height, setHeight] = useState<number>(20);
-  const [width, setWidth] = useState<number>(20);
-
-  // sync current
-  useEffect(() => {
-    const checkTooltip = () => {
-      const current = windowManager.getTooltip();
-      setCurrent(current);
-    };
-    windowManager.on(WindowManagerEvent.TooltipUpdated, checkTooltip);
-    return () => {
-      windowManager.removeListener(
-        WindowManagerEvent.TooltipUpdated,
-        checkTooltip
-      );
-    };
-  }, [windowManager]);
-
-  useEffect(() => {
-    const doMouseMove = (e) => {
-      setLeft(e.clientX);
-      setTop(e.clientY);
-    };
-
-    const checkTooltip = () => {
-      const current = windowManager.getTooltip();
-      if (current === TooltipName.None) setVisible(false);
-      else setVisible(true);
-    };
-
-    window.addEventListener('mousemove', doMouseMove);
-    windowManager.on(WindowManagerEvent.TooltipUpdated, checkTooltip);
-
-    return () => {
-      window.removeEventListener('mousemove', doMouseMove);
-      windowManager.removeListener(
-        WindowManagerEvent.TooltipUpdated,
-        checkTooltip
-      );
-    };
-  }, [windowManager, height, width]);
-
-  useLayoutEffect(() => {
-    setHeight(elRef.current.offsetHeight);
-    setWidth(elRef.current.offsetWidth);
-  }, [elRef.current.offsetHeight, elRef, visible]);
-
-  useLayoutEffect(() => {
-    if (left < window.innerWidth / 2) {
-      setLeftOffset(10);
-    } else {
-      setLeftOffset(-10 - width);
-    }
-
-    if (top < window.innerHeight / 2) {
-      setTopOffset(10);
-    } else {
-      setTopOffset(-10 - height);
-    }
-  }, [left, top, width, height]);
-
-  const tooltipArr: Array<React.ReactNode> = [];
-  tooltipArr[TooltipName.None] = <></>;
-
   return (
-    <StyledTooltip
-      ref={elRef}
-      onMouseEnter={(e) => e.preventDefault()}
-      onMouseLeave={(e) => e.preventDefault()}
-      style={{
-        top: `${top + topOffset}px`,
-        left: `${left + leftOffset}px`,
-      }}
-      visible={visible}
-    >
-      <TooltipContent name={current} />
-    </StyledTooltip>
+    null
   );
 }

--- a/client/src/app/board/CanvasRenderer.ts
+++ b/client/src/app/board/CanvasRenderer.ts
@@ -37,7 +37,6 @@ class CanvasRenderer {
 
   canvasRef: RefObject<HTMLCanvasElement>;
   canvas: HTMLCanvasElement;
-  offscreenCanvas: any;
   ctx: CanvasRenderingContext2D;
   frameRequestId: number;
   gameUIManager: GameUIManager;
@@ -160,12 +159,6 @@ class CanvasRenderer {
     this.drawBorders();
 
     this.drawMiner();
-
-    const renderCtx = this.canvas.getContext('bitmaprenderer');
-    if (renderCtx) {
-      const offscreenBitmap = this.offscreenCanvas.transferToImageBitmap();
-      renderCtx.transferFromImageBitmap(offscreenBitmap);
-    }
 
     this.frameRequestId = window.requestAnimationFrame(this.frame.bind(this));
   }

--- a/client/src/utils/WindowManager.ts
+++ b/client/src/utils/WindowManager.ts
@@ -24,9 +24,6 @@ export enum WindowManagerEvent {
   StateChanged = 'StateChanged',
   MiningCoordsUpdate = 'MiningCoordsUpdate',
   TooltipUpdated = 'TooltipUpdated',
-
-  ShiftDown = 'ShiftDown',
-  ShiftUp = 'ShiftUp',
 }
 
 export enum CursorState {
@@ -106,23 +103,6 @@ class WindowManager extends EventEmitter {
     this.lastZIndex = 0;
     this.tooltipStack = [];
     this.shiftPressed = false;
-
-    // this might be slow, consider refactor
-    this.setMaxListeners(40); // however many tooltips there are
-
-    // is it bad that this doesn't get cleaned up?
-    window.addEventListener('keydown', (e) => {
-      if (e.key === 'Shift') {
-        this.shiftPressed = true;
-        this.emit(WindowManagerEvent.ShiftDown);
-      }
-    });
-    window.addEventListener('keyup', (e) => {
-      if (e.key === 'Shift') {
-        this.shiftPressed = false;
-        this.emit(WindowManagerEvent.ShiftUp);
-      }
-    });
   }
 
   static getInstance(): WindowManager {


### PR DESCRIPTION
Perf stuff with reasonings:
* Turn off (delete) tooltips because their hover logic was causing insane amounts of react re-renders
* Remove the setTimeout around planet updates because `performance.measure` testing claims the whole loop takes 50ms