### PR TITLE
client: embed upgrade buttons into the context pane

### DIFF
--- a/client/src/app/GameWindowPanes/PlanetContextPane.tsx
+++ b/client/src/app/GameWindowPanes/PlanetContextPane.tsx
@@ -290,6 +290,10 @@ const StyledUpgradeButton = styled.div<{ active: boolean }>`
     active && `color: ${dfstyles.colors.background} !important`};
   }
 
+  & svg path {
+    ${({ active }) => active && `fill: ${dfstyles.colors.background} !important`}
+  }
+
   & p > span {
     vertical-align: middle;
   }


### PR DESCRIPTION
This moves the upgrade buttons into the planet context pane for fast upgrading.

I want to test it a bit more before merging.