### PR TITLE
client: reimplement client pulling all chunks, but chop them up

### DIFF
--- a/client/src/api/GameManager.ts
+++ b/client/src/api/GameManager.ts
@@ -368,11 +368,16 @@ class GameManager extends EventEmitter implements AbstractGameManager {
       this.explorers = new Map();
 
       this.explorerIPs.forEach((ip) => {
-        const explorer = new window.Primus(ip);
+        const explorer = new window.Primus(ip, {
+          strategy: ['disconnect', 'online']
+        });
         explorer.on('new-chunk', (chunk) => {
           this.lastChunkPerExplorer.set(ip, chunk.chunkFootprint);
           this.addNewChunk(chunk);
           this.emit(GameManagerEvent.DiscoveredNewChunk, chunk);
+        });
+        explorer.on('sync-chunks', (chunks) => {
+          chunks.forEach((chunk) => this.addNewChunk(chunk));
         });
         explorer.on('hash-rate', (hashRate) => {
           this.hashRatePerExplorer.set(ip, hashRate);

--- a/index.mjs
+++ b/index.mjs
@@ -246,6 +246,18 @@ if (isWebsocketServer) {
         .then(() => console.log(`Updated WORLD_RADIUS to ${radius} in .env`))
         .catch(() => console.log(`Failed to update WORLD_RADIUS to ${radius} in .env`));
     });
+
+    // Only send sync chunks with 200 objects in them
+    let chunks = [];
+    for (let chunk of localStorageManager.allChunks()) {
+      if (chunks.length < 200) {
+        chunks.push(chunk);
+      } else {
+        spark.emit('sync-chunks', chunks);
+        chunks = [];
+      }
+    }
+    chunks = null;
   });
 }
 


### PR DESCRIPTION
This reimplements sending the entire map when a client connects, but it chops it up into 200 object slices. This also caused the primus heartbeat to skip and caused a reconnect so I disabled the heartbeat reconnect strategy.

This still might need to be improved.