### PR TITLE
explorer: add deep space perlin threshold for determining valid chunk

### DIFF
--- a/lib/MinerManager.mjs
+++ b/lib/MinerManager.mjs
@@ -188,6 +188,10 @@ export class MinerManager extends EventEmitter {
     const xMinAbs = Math.abs(xCenter) - sideLength / 2;
     const yMinAbs = Math.abs(yCenter) - sideLength / 2;
     const squareDist = xMinAbs ** 2 + yMinAbs ** 2;
+    const p = perlin({ x: xCenter, y: yCenter }, false);
+    if (p < 17) {
+      return false;
+    }
     // should be inbounds, and unexplored
     return (
       squareDist < this.worldRadius ** 2 &&


### PR DESCRIPTION
This builds on #37 to make the mining manager only allocates deep space chunks to the miner. I moved the check inside of `isValidExploreTarget`.

I'll keep this as a branch for when we want to use it because we don't have a way to toggle.