### PR TITLE
client: send exact silver if non-asteroid planet

### DIFF
--- a/client/src/app/board/GameUIManager.ts
+++ b/client/src/app/board/GameUIManager.ts
@@ -265,10 +265,9 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
           (mouseDownCoords.y - mouseUpOverCoords.y) ** 2
         );
         const myAtk: number = moveShipsDecay(forces, mouseDownPlanet, dist);
-        const effPercentSilver = Math.min(
-          this.getSilverSending(from.locationId),
-          98
-        );
+        const effPercentSilver = from.resource === PlanetResource.NONE
+          ? this.getSilverSending(from.locationId)
+          : Math.min(this.getSilverSending(from.locationId), 98);
         if (myAtk > 0) {
           const silver = Math.floor((from.silver * effPercentSilver) / 100);
           // TODO: do something like JSON.stringify(args) so we know formatting is correct


### PR DESCRIPTION
This adds a check for the planet resource before rounding down to 98% of silver amount when sending the max. This is needed for asteroids, but we should be able to send a static amount from planets because they don't produce silver.