### PR TITLE
client: vary voyage color based on own/attack/neutral movement

### DIFF
--- a/client/src/app/board/CanvasRenderer.ts
+++ b/client/src/app/board/CanvasRenderer.ts
@@ -531,15 +531,26 @@ class CanvasRenderer {
     const fromLoc = this.gameUIManager.getLocationOfPlanet(from);
     const fromPlanet = this.gameUIManager.getPlanetWithId(from);
     const toLoc = this.gameUIManager.getLocationOfPlanet(to);
-    if (!fromPlanet || !fromLoc || !toLoc) {
+    const toPlanet = this.gameUIManager.getPlanetWithId(to);
+    if (!fromPlanet || !fromLoc || !toLoc || !toPlanet) {
       return;
+    }
+
+    const isAttack = fromPlanet.owner !== toPlanet.owner && toPlanet.owner !== emptyAddress;
+    let lineColor;
+    if (isMyVoyage) {
+      lineColor = 'blue';
+    } else if (isAttack) {
+      lineColor = 'red';
+    } else {
+      lineColor = getOwnerColor(fromPlanet);
     }
 
     this.drawLine(
       fromLoc.coords,
       toLoc.coords,
       confirmed ? 2 : 1,
-      isMyVoyage ? 'blue' : 'red',
+      lineColor,
       confirmed ? false : true
     );
   }


### PR DESCRIPTION
I got sick of seeing red lines for every movement. This helps distinguish whether attacks are hostile or just exploratory by color.