### PR TITLE
client: ensure escape key ends forces sending

### DIFF
--- a/client/src/app/GameWindow.tsx
+++ b/client/src/app/GameWindow.tsx
@@ -35,9 +35,11 @@ export default function GameWindow() {
     if (!uiManager) return;
 
     const onKeypress = (e) => {
+      const uiEmitter = UIEmitter.getInstance();
       if (e.key === 'Escape') {
         setSelected(null);
         uiManager?.setSelectedPlanet(null);
+        uiEmitter.emit(UIEmitterEvent.SendCancelled);
       }
     };
 

--- a/client/src/app/GameWindowPanes/PlanetContextPane.tsx
+++ b/client/src/app/GameWindowPanes/PlanetContextPane.tsx
@@ -395,6 +395,21 @@ export function PlanetContextPane({ hook, upgradeDetHook }: { hook: ModalHook, u
   useEffect(() => {
     if (!uiManager) return;
     setAccount(uiManager.getAccount());
+
+    const uiEmitter = UIEmitter.getInstance();
+
+    const onKeypress = (e) => {
+      if (e.key === 'Escape') {
+        setSending(false);
+        windowManager.setCursorState(CursorState.Normal);
+        uiEmitter.emit(UIEmitterEvent.SendCancelled);
+      }
+    };
+
+    document.addEventListener('keydown', onKeypress);
+    return () => {
+      document.removeEventListener('keydown', onKeypress);
+    };
   }, [uiManager]);
 
   const planetName = (): string => {

--- a/client/src/app/board/GameUIManager.ts
+++ b/client/src/app/board/GameUIManager.ts
@@ -398,6 +398,7 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
   }
 
   onSendCancel(): void {
+    this.mouseDownOverPlanet = null;
     this.isSending = false;
     this.sendingPlanet = null;
     this.sendingCoords = null;


### PR DESCRIPTION
The escape key now cancels all sending, whether using the "Send Resources" button or while click-dragging.