### PR TITLE
explorer: save the PRELOAD_MAP env variable

### DIFF
--- a/lib/parse-utils.mjs
+++ b/lib/parse-utils.mjs
@@ -1,3 +1,11 @@
+import path from 'path';
+
+export function toFullPath(val) {
+  if (typeof val === 'string') {
+    return path.resolve(process.cwd(), val);
+  }
+}
+
 export function toBoolean(val) {
   if (typeof val === 'string') {
     return val.toLowerCase() === 'true';


### PR DESCRIPTION
@jacobrosenthal you can now add a PRELOAD_MAP value into the `.env` (and it should write it after the first prompt)