### PR TITLE
client: implement a global asteroid distributor

### DIFF
--- a/client/src/api/AbstractGameManager.ts
+++ b/client/src/api/AbstractGameManager.ts
@@ -98,5 +98,5 @@ export default interface AbstractGameManager extends EventEmitter {
   getTimeForMove(fromId: LocationId, toId: LocationId): number;
   getTemperature(coords: WorldCoords): number;
 
-  distributeSilver(fromId: LocationId, maxDistributeEnergyPercent: number): void;
+  async distributeSilver(fromId: LocationId, maxDistributeEnergyPercent: number): Promise<void>;
 }

--- a/client/src/app/GameWindowPanes/PlanetContextPane.tsx
+++ b/client/src/app/GameWindowPanes/PlanetContextPane.tsx
@@ -436,13 +436,15 @@ export function PlanetContextPane({ hook, upgradeDetHook }: { hook: ModalHook, u
   useEffect(() => {
     if (!uiManager || !selected || !distributing) return;
 
-    try {
-      uiManager.distributeSilver(selected.locationId, maxDistributeEnergyPercent)
-      console.log('Successfully distributed silver');
-    } catch (err) {
-      console.error('Failed to distribute silver', err)
-    }
-    setDistributing(false);
+    uiManager.distributeSilver(selected.locationId, maxDistributeEnergyPercent)
+      .then(() => {
+        console.log('Successfully distributed silver');
+        setDistributing(false);
+      })
+      .catch((err) => {
+        console.error('Failed to distribute silver', err)
+        setDistributing(false);
+      });
   }, [distributing, selected, uiManager, maxDistributeEnergyPercent]);
 
   const energyHook = useState<number>(

--- a/client/src/app/board/AbstractUIManager.ts
+++ b/client/src/app/board/AbstractUIManager.ts
@@ -109,5 +109,5 @@ export default interface AbstractUIManager {
   getTimeForMove(fromId: LocationId, toId: LocationId): number;
   getTemperature(coords: WorldCoords): number;
 
-  distributeSilver(fromId: LocationId, maxDistributeEnergyPercent: number): void
+  async distributeSilver(fromId: LocationId, maxDistributeEnergyPercent: number): Promise<void>
 }

--- a/client/src/app/board/GameUIManager.ts
+++ b/client/src/app/board/GameUIManager.ts
@@ -695,8 +695,8 @@ class GameUIManager extends EventEmitter implements AbstractUIManager {
     this.gameManager.move(from, to, forces, silver);
   }
 
-  distributeSilver(fromId: LocationId, maxDistributeEnergyPercent: number): void {
-    this.gameManager.distributeSilver(fromId, maxDistributeEnergyPercent)
+  async distributeSilver(fromId: LocationId, maxDistributeEnergyPercent: number): Promise<void> {
+    return this.gameManager.distributeSilver(fromId, maxDistributeEnergyPercent)
   }
 }
 


### PR DESCRIPTION
This adds a button to the Planet Dex to distribute from all your asteroids. They will remain at 35% of their max energy and spider outwards to fill in your planets silver.

I also had to duplicate the move method and make everything async/promise returning so we can wait on each request to complete because this blows everything up.

I also added a 100 silver buffer on the top of a planet because it's probably not worth the pop (you can use the planet dex to view non-capped planets). If this is a big issue, I think we could drop it to 0.