### PR TITLE
client: fix auto upgrade max off by one

### DIFF
--- a/client/src/app/GameWindowPanes/PlanetDexPane.tsx
+++ b/client/src/app/GameWindowPanes/PlanetDexPane.tsx
@@ -462,8 +462,8 @@ export function PlanetDexPane({ hook }: { hook: ModalHook; }): JSX.Element {
           planet.silver >= getUpgradeSilverNeeded(planet) &&
           planet.unconfirmedUpgrades?.length === 0
         ) {
-          // 3 (a.ka. 4) is the max level an upgrade can be
-          if (planet.upgradeState[autoUpgradeBranch] < 3) {
+          // 4 is the max level an upgrade can be
+          if (planet.upgradeState[autoUpgradeBranch] < 4) {
             return true;
           } else {
             console.log(`AutoUpgrade: Can't upgrade past level 4, try a different stat`);


### PR DESCRIPTION
It's 0 indexed, but it can still go to 4. Whoops.