### PR TITLE
client: set the client polling to 8000 to seemingly reduce failures

### DIFF
--- a/client/src/api/EthereumAccountManager.ts
+++ b/client/src/api/EthereumAccountManager.ts
@@ -45,6 +45,7 @@ class EthereumAccountManager extends EventEmitter {
     try {
       this.rpcURL = url;
       const newProvider = new providers.JsonRpcProvider(this.rpcURL);
+      newProvider.pollingInterval = 8000;
       // TODO: the chainID check
       this.provider = newProvider;
       if (this.signer) {


### PR DESCRIPTION
Set the polling to 8000 on the JsonRpc provider. I don't actually know if this helps at all.