### PR TITLE
client: only setup localhost explorer if you start websocket

### DIFF
--- a/client/src/api/GameManager.ts
+++ b/client/src/api/GameManager.ts
@@ -101,7 +101,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
 
   private readonly endTimeSeconds: number = 1609372800;
 
-  explorerIPs: string[];
+  explorerUrls: string[];
   explorers: Map<string, any>;
   lastChunkPerExplorer: Map<string, ChunkFootprint>;
   hashRatePerExplorer: Map<string, number>;
@@ -123,12 +123,10 @@ class GameManager extends EventEmitter implements AbstractGameManager {
   ) {
     super();
 
-    const port = import.meta.env.PORT ? `:${import.meta.env.PORT}` : '';
-
-    this.explorerIPs = [
-      `http://0.0.0.0${port}`,
-      'http://165.232.57.41',
-    ];
+    this.explorerUrls = [];
+    if (import.meta.env.EXPLORER_URL) {
+      this.explorerUrls.push(import.meta.env.EXPLORER_URL);
+    }
     this.explorers = new Map();
     this.lastChunkPerExplorer = new Map();
     this.hashRatePerExplorer = new Map();
@@ -383,7 +381,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
 
   private initMiningManager(_: WorldCoords): void {
     if (window.Primus) {
-      this.explorerIPs.forEach((ip) => {
+      this.explorerUrls.forEach((ip) => {
         const explorer = new window.Primus(ip);
         explorer.on('new-chunk', (chunk) => {
           this.lastChunkPerExplorer.set(ip, chunk.chunkFootprint);

--- a/index.mjs
+++ b/index.mjs
@@ -311,7 +311,11 @@ const minerManager = MinerManager.create(
 let server;
 
 if (isClientServer) {
-  const config = viteConfig({ port });
+  const config = viteConfig({
+    env: {
+      EXPLORER_URL: (isWebsocketServer && shouldExplore) ? `http://localhost:${port}` : null,
+    },
+  });
   server = createServer(config);
 } else if (isWebsocketServer) {
   server = http.createServer();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "workspaces": [
     "client"
   ],
+  "engines": {
+    "node": ">=14.13.0"
+  },
   "dependencies": {
     "big-integer": "^1.6.48",
     "dotenv": "^8.2.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const VitePluginReact = require('vite-plugin-react');
 
-const viteConfig = ({ port = 8082, ...rest }) => ({
+const viteConfig = ({ ...rest }) => ({
   root: path.join(__dirname, 'client'),
   alias: {
     'react': '@pika/react',
@@ -15,9 +15,6 @@ const viteConfig = ({ port = 8082, ...rest }) => ({
   jsx: 'react',
   optimizeDeps: {
     include: ['auto-bind/index', 'stylis-rule-sheet'],
-  },
-  env: {
-    PORT: port,
   },
   // Explictly don't add the plugin resolvers because
   // we want prod React to make warnings go away


### PR DESCRIPTION
This is just cleaning up the way we handle the explorer's websocket connection on the client. Could be expanded into config options.